### PR TITLE
Add-unit-testing-capabilities

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,11 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src/odoo",
+                "ODOO_RC": "${workspaceFolder}/config/odoo.conf",
+                "OPENERP_SERVER": "${workspaceFolder}/config/odoo.conf"
+            }
         },
         {
             "name": "Odoo Attach Docker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "src/odoo_enterprise"
     ],
     "python.testing.pytestArgs": [
-        "PATH_TO_TESTS",
+        "addons/",
         "--odoo-database",
         "odoo-db",
         "--odoo-config",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,23 @@
         "src/odoo",
         "src/odoo_enterprise"
     ],
-    "search.useIgnoreFiles": false
+    "python.testing.pytestArgs": [
+        "PATH_TO_TESTS",
+        "--odoo-database",
+        "odoo-db",
+        "--odoo-config",
+        "config/odoo.conf"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "terminal.integrated.env.windows": {
+        "PYTHONPATH": "${workspaceFolder}/src/odoo",
+        "ODOO_RC": "${workspaceFolder}/config/odoo.conf",
+        "OPENERP_SERVER": "${workspaceFolder}/config/odoo.conf"
+    },
+    "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${workspaceFolder}/src/odoo",
+        "ODOO_RC": "${workspaceFolder}/config/odoo.conf",
+        "OPENERP_SERVER": "${workspaceFolder}/config/odoo.conf"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,10 +10,8 @@
     ],
     "python.testing.pytestArgs": [
         "addons/",
-        "--odoo-database",
-        "odoo-db",
-        "--odoo-config",
-        "config/odoo.conf"
+        "--odoo-database=odoo-db",
+        "--odoo-config=config/odoo.conf"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,28 @@ The project is a combination of
 <!--                                WSL Setup                                -->
 <!-- ----------------------------------------------------------------------- -->
 
+## VS Code Odoo Pytest setup
+
+Follow the WSL setup instructions to get a working Odoo dev environment first.
+
+Then, from your virtual env (remember to use `source venv/bin/activate` to get into your venv), install [pytest 7.4.3](https://pypi.org/project/pytest/7.4.3/) and [pytest-odoo](https://github.com/camptocamp/pytest-odoo) :
+
+```bash
+pip install pytest==7.4.3
+pip install pytest-odoo
+```
+
+Then, install Odoo as a pip package :
+
+```bash
+cd ./src/odoo
+pip install -e .
+```
+
+You should now see odoo when doing a `pip list`.
+
+You can now configure PyTest on VS Code, but it should work just fine using the `settings.json` and `config/odoo.conf` files provided in this repository.
+
 ## WSL Setup
 
 File structure :

--- a/config/odoo.conf
+++ b/config/odoo.conf
@@ -1,7 +1,6 @@
 [options]
-addons_path = /mnt/extra-addons
-data_dir = /var/lib/odoo
-db_host = db
+addons_path = COMMA_SEPARATED_ADDONS_PATH
+db_host = localhost
 db_port = 5432
 dbfilter = ^odoo-db$
 db_name = odoo-db


### PR DESCRIPTION
Added unit testing capabilities and configs to odoo-dev-env.

I still don't have much of a Docker dev env, but the WSL one is now complete.

I'll work on a better Docker dev env soon, with support for both at the same time to have a Docker instance for testing and a local one for dev I guess.

Anyway, don't use the Docker one yet, the WSL dev env is done o/